### PR TITLE
Update ardrone navigation driver example docs

### DIFF
--- a/source/documentation/drivers/ardrone-navigation.html.haml
+++ b/source/documentation/drivers/ardrone-navigation.html.haml
@@ -38,7 +38,7 @@ subnavjs: true
 
           devices: {
             drone: { driver: 'ardrone' },
-            nav: { driver: 'ardroneNav' }
+            nav: { driver: 'ardrone-nav' }
           }
         });
 
@@ -59,13 +59,13 @@ subnavjs: true
 
           devices: {
             drone: { driver: 'ardrone' },
-            nav: { driver: 'ardroneNav' }
+            nav: { driver: 'ardrone-nav' }
           },
 
           work: function(my) {
             my.drone.config('general:navdata_demo', 'TRUE');
 
-            my.nav.on('update', function(data) {
+            my.nav.on('navdata', function(data) {
               console.log(data);
             }
           }


### PR DESCRIPTION
Hi again :blush:

In the same vein as https://github.com/hybridgroup/cylon-ardrone/pull/23 just thought I'd send through a quick patch to the `cylon-ardrone` navigation driver docs

- Not sure if these example files (https://github.com/hybridgroup/cylon-site/blob/master/source/documentation/examples/ardrone/js/drone_nav.html.haml) need updating too or if the code is just pulled through from the `cylon-ardrone` repo automatically somehow, let me know if I should extend the patch there too

Cheers