### PR TITLE
Fix module name inconsistency

### DIFF
--- a/source/documentation/drivers/analog-sensor.html.haml
+++ b/source/documentation/drivers/analog-sensor.html.haml
@@ -34,7 +34,7 @@ subnavjs: true
           },
 
           devices: {
-            sensor: { driver: 'analogSensor', pin: 0, lowerLimit: 100, upperLimit: 900 }
+            sensor: { driver: 'analog-sensor', pin: 0, lowerLimit: 100, upperLimit: 900 }
           }
         });
 
@@ -53,7 +53,7 @@ subnavjs: true
           },
 
           devices: {
-            sensor: { driver: 'analogSensor', pin: 0, lowerLimit: 100, upperLimit: 900 }
+            sensor: { driver: 'analog-sensor', pin: 0, lowerLimit: 100, upperLimit: 900 }
           },
 
           work: function(my) {


### PR DESCRIPTION
Looking at other modules it seems to me that ```analog-sensor``` would be preferred.